### PR TITLE
[BUGFIX] Fix the Today page HierarchyRequestError

### DIFF
--- a/nuxt/pages/today.vue
+++ b/nuxt/pages/today.vue
@@ -32,19 +32,21 @@
             </div>
           </div>
           <div class="entry-container" role="list" data-testid="log-entries">
-            <log-entry
-              v-for="entry of logEntriesForToday"
-              :key="entry.id"
-              role="listitem"
-              :passage="entry"
-              :actions="actionsForTodayLogEntry(entry)"
-            />
-            <log-entry
-              v-if="!logEntriesForToday.length"
-              key="no-entries"
-              role="listitem"
-              :message="$t('no_entries')"
-            />
+            <client-only>
+              <log-entry
+                v-for="entry of logEntriesForToday"
+                :key="entry.id"
+                role="listitem"
+                :passage="entry"
+                :actions="actionsForTodayLogEntry(entry)"
+              />
+              <log-entry
+                v-if="!logEntriesForToday.length"
+                key="no-entries"
+                role="listitem"
+                :message="$t('no_entries')"
+              />
+            </client-only>
           </div>
           <br>
           <h3 class="title is-5">


### PR DESCRIPTION
# Pull Request

## Description

See #5 for more background. The Today page would fail to load after SSR. If another page was loaded (by refreshing while on that page, such as Calendar or Notes), it was possible to navigate to the Today page and not experience an error. If the Today page was loaded directly, a HierarchyRequestError would occur and the page would be unusable.

After trying several solutions, the final fix was to wrap the list of log entries on the Today page in the `<client-only>` component.

Other changes in this PR:

* `v-if` components on Today page have a `key` attribute (allowed in Vue 2)
* reading suggestions on the Today page are also wrapped in `<client-only>`, but this was tried before wrapping the actual log entries and it didn't solve the issue
* An unused `displayDate` helper function import has been removed
