### PR TITLE
Translations for current locale appear at top of options

### DIFF
--- a/e2e/tests/app/settings.spec.ts
+++ b/e2e/tests/app/settings.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../fixtures';
-import { login } from '../../helpers/api-client';
+import { login, createTestUser, deleteTestUser } from '../../helpers/api-client';
+import { env } from '../../helpers/env';
 
 test.describe('Settings', () => {
   test('settings pages are marked noindex', async ({ page }) => {
@@ -73,5 +74,27 @@ test.describe('Settings', () => {
 
     // The form surfaces an error and the password is unchanged
     await expect(page.locator('.mbl-help--danger').first()).toBeVisible();
+  });
+
+  test('non-English locale sees locale translations at the top of the Bible version list', async ({ browser }) => {
+    const germanUser = await createTestUser({ locale: 'de' });
+    const ctx = await browser.newContext({ baseURL: env.siteUrl });
+    try {
+      await ctx.addCookies([
+        { name: 'auth_token', value: germanUser.token, url: env.siteUrl, httpOnly: true, sameSite: 'Lax' },
+        { name: 'i18n_redirected', value: 'de', url: env.siteUrl },
+      ]);
+      const page = await ctx.newPage();
+      await page.goto('/de/settings/reading');
+
+      const select = page.getByTestId('settings-bible-version-select');
+      // nth(0) is the disabled placeholder; nth(1) is the first real option
+      const firstOption = select.locator('option').nth(1);
+      await expect(firstOption).toHaveAttribute('value', 'LUT');
+    }
+    finally {
+      await ctx.close();
+      await deleteTestUser(germanUser);
+    }
   });
 });

--- a/nuxt/components/forms/settings/PreferredBibleVersionForm.vue
+++ b/nuxt/components/forms/settings/PreferredBibleVersionForm.vue
@@ -72,55 +72,9 @@
 </template>
 
 <script>
-import { BibleVersions, BibleApps } from '@mybiblelog/shared';
+import { bibleVersionOptions as allBibleVersionOptions, bibleAppOptions, localeVersionGroups } from '@mybiblelog/shared';
 import { useToastStore } from '~/stores/toast';
 import { useUserSettingsStore } from '~/stores/user-settings';
-
-const bibleVersionNames = {
-  [BibleVersions.NASB2020]: 'New American Standard Bible (NASB)',
-  [BibleVersions.NASB1995]: 'New American Standard Bible 1995 (NASB 1995)',
-  [BibleVersions.AMP]: 'Amplified Bible (AMP)',
-  [BibleVersions.KJV]: 'King James Version (KJV)',
-  [BibleVersions.NKJV]: 'New King James Version (NKJV)',
-  [BibleVersions.NIV]: 'New International Version (NIV)',
-  [BibleVersions.ESV]: 'English Standard Version (ESV)',
-  [BibleVersions.NABRE]: 'New American Bible Revised Edition (NABRE)',
-  [BibleVersions.NLT]: 'New Living Translation (NLT)',
-  [BibleVersions.TPT]: 'The Passion Translation (TPT)',
-  [BibleVersions.MSG]: 'The Message (MSG)',
-  [BibleVersions.RVR1960]: 'Reina-Valera 1960 (RVR1960)',
-  [BibleVersions.RVR2020]: 'Reina-Valera 2020 (RVR2020)',
-  [BibleVersions.UKR]: 'українська (UKRK)',
-  [BibleVersions.BDS]: 'Bible du Semeur (BDS)',
-  [BibleVersions.LSG]: 'Louis Segond (LSG)',
-  [BibleVersions.ARC]: 'Almeida Revista e Corrigida (ARC)',
-  [BibleVersions.LUT]: 'Luther 1545 (LUT)',
-  [BibleVersions.KRV]: '개역한글 (KRV)',
-};
-
-const bibleVersionOptions = Object.keys(bibleVersionNames).map((key) => {
-  const value = bibleVersionNames[key];
-  return {
-    text: value,
-    value: key,
-  };
-});
-
-const bibleAppNames = {
-  [BibleApps.BIBLEGATEWAY]: 'Bible Gateway',
-  [BibleApps.YOUVERSIONAPP]: 'YouVersion App',
-  [BibleApps.BIBLECOM]: 'Bible.com (YouVersion)',
-  [BibleApps.BLUELETTERBIBLE]: 'Blue Letter Bible',
-  [BibleApps.OLIVETREE]: 'Olive Tree App',
-};
-
-const bibleAppOptions = Object.keys(bibleAppNames).map((key) => {
-  const value = bibleAppNames[key];
-  return {
-    text: value,
-    value: key,
-  };
-});
 
 export default {
   name: 'PreferredBibleVersionForm',
@@ -150,11 +104,22 @@ export default {
     return {
       preferredBibleVersion: this.initialValue || '',
       preferredBibleApp: this.initialBibleApp || '',
-      bibleVersionOptions,
       bibleAppOptions,
       error: '',
       isSaving: false,
     };
+  },
+  computed: {
+    bibleVersionOptions() {
+      const locale = this.$i18n?.locale || 'en';
+      const group = localeVersionGroups[locale] || [];
+      return [...allBibleVersionOptions].sort((a, b) => {
+        const aLocal = group.includes(a.value);
+        const bLocal = group.includes(b.value);
+        if (aLocal === bLocal) { return 0; }
+        return aLocal ? -1 : 1;
+      });
+    },
   },
   watch: {
     initialValue(newValue) {

--- a/nuxt/pages/settings/reading.vue
+++ b/nuxt/pages/settings/reading.vue
@@ -107,63 +107,15 @@
 </template>
 
 <script>
-import { BibleApps, BibleVersions } from '@mybiblelog/shared';
+import { bibleVersionOptions as allBibleVersionOptions, bibleAppOptions, localeVersionGroups } from '@mybiblelog/shared';
 import { useToastStore } from '~/stores/toast';
 import { useUserSettingsStore } from '~/stores/user-settings';
-
-const bibleVersionNames = {
-  [BibleVersions.NASB2020]: 'New American Standard Bible (NASB)',
-  [BibleVersions.NASB1995]: 'New American Standard Bible 1995 (NASB 1995)',
-  [BibleVersions.AMP]: 'Amplified Bible (AMP)',
-  [BibleVersions.KJV]: 'King James Version (KJV)',
-  [BibleVersions.NKJV]: 'New King James Version (NKJV)',
-  [BibleVersions.NIV]: 'New International Version (NIV)',
-  [BibleVersions.ESV]: 'English Standard Version (ESV)',
-  [BibleVersions.NABRE]: 'New American Bible Revised Edition (NABRE)',
-  [BibleVersions.NLT]: 'New Living Translation (NLT)',
-  [BibleVersions.TPT]: 'The Passion Translation (TPT)',
-  [BibleVersions.MSG]: 'The Message (MSG)',
-  [BibleVersions.RVR1960]: 'Reina-Valera 1960 (RVR1960)',
-  [BibleVersions.RVR2020]: 'Reina-Valera 2020 (RVR2020)',
-  [BibleVersions.UKR]: 'українська (UKRK)',
-  [BibleVersions.BDS]: 'Bible du Semeur (BDS)',
-  [BibleVersions.LSG]: 'Louis Segond (LSG)',
-  [BibleVersions.ARC]: 'Almeida Revista e Corrigida (ARC)',
-  [BibleVersions.LUT]: 'Luther 1545 (LUT)',
-  [BibleVersions.KLB]: '한글성경 (KLB)',
-  [BibleVersions.KRV]: '개역한글 (KRV)',
-};
-
-const bibleAppNames = {
-  [BibleApps.BIBLEGATEWAY]: 'Bible Gateway',
-  [BibleApps.YOUVERSIONAPP]: 'YouVersion App',
-  [BibleApps.BIBLECOM]: 'Bible.com (YouVersion)',
-  [BibleApps.BLUELETTERBIBLE]: 'Blue Letter Bible',
-  [BibleApps.OLIVETREE]: 'Olive Tree App',
-};
-
-const bibleVersionOptions = Object.keys(bibleVersionNames).map((key) => {
-  const value = bibleVersionNames[key];
-  return {
-    text: value,
-    value: key,
-  };
-});
-
-const bibleAppOptions = Object.keys(bibleAppNames).map((key) => {
-  const value = bibleAppNames[key];
-  return {
-    text: value,
-    value: key,
-  };
-});
 
 export default {
   name: 'ReadingSettingsPage',
   middleware: ['auth'],
   data() {
     return {
-      bibleVersionOptions,
       bibleAppOptions,
       userSettingsForm: {
         lookBackDate: '',
@@ -189,6 +141,16 @@ export default {
   computed: {
     userSettings() {
       return useUserSettingsStore().settings;
+    },
+    bibleVersionOptions() {
+      const locale = this.$i18n?.locale || 'en';
+      const group = localeVersionGroups[locale] || [];
+      return [...allBibleVersionOptions].sort((a, b) => {
+        const aLocal = group.includes(a.value);
+        const bLocal = group.includes(b.value);
+        if (aLocal === bLocal) { return 0; }
+        return aLocal ? -1 : 1;
+      });
     },
     bibleReadingDays() {
       if (!this.userSettings.dailyVerseCountGoal) {

--- a/shared/bible-apps.ts
+++ b/shared/bible-apps.ts
@@ -202,3 +202,48 @@ export const getDefaultBibleApp = () => {
 export const getDefaultBibleVersion = () => {
   return BibleVersions.NASB2020;
 };
+
+export const bibleVersionNames: Record<typeof BibleVersions[keyof typeof BibleVersions], string> = {
+  [BibleVersions.NASB2020]: 'New American Standard Bible (NASB)',
+  [BibleVersions.NASB1995]: 'New American Standard Bible 1995 (NASB 1995)',
+  [BibleVersions.AMP]: 'Amplified Bible (AMP)',
+  [BibleVersions.KJV]: 'King James Version (KJV)',
+  [BibleVersions.NKJV]: 'New King James Version (NKJV)',
+  [BibleVersions.NIV]: 'New International Version (NIV)',
+  [BibleVersions.ESV]: 'English Standard Version (ESV)',
+  [BibleVersions.NABRE]: 'New American Bible Revised Edition (NABRE)',
+  [BibleVersions.NLT]: 'New Living Translation (NLT)',
+  [BibleVersions.TPT]: 'The Passion Translation (TPT)',
+  [BibleVersions.MSG]: 'The Message (MSG)',
+  [BibleVersions.RVR1960]: 'Reina-Valera 1960 (RVR1960)',
+  [BibleVersions.RVR2020]: 'Reina-Valera 2020 (RVR2020)',
+  [BibleVersions.UKR]: 'українська (UKRK)',
+  [BibleVersions.BDS]: 'Bible du Semeur (BDS)',
+  [BibleVersions.LSG]: 'Louis Segond (LSG)',
+  [BibleVersions.ARC]: 'Almeida Revista e Corrigida (ARC)',
+  [BibleVersions.LUT]: 'Luther 1545 (LUT)',
+  [BibleVersions.KLB]: '한글성경 (KLB)',
+  [BibleVersions.KRV]: '개역한글 (KRV)',
+};
+
+export const bibleVersionOptions = Object.entries(bibleVersionNames).map(([value, text]) => ({ text, value }));
+
+export const bibleAppNames: Record<typeof BibleApps[keyof typeof BibleApps], string> = {
+  [BibleApps.BIBLEGATEWAY]: 'Bible Gateway',
+  [BibleApps.YOUVERSIONAPP]: 'YouVersion App',
+  [BibleApps.BIBLECOM]: 'Bible.com (YouVersion)',
+  [BibleApps.BLUELETTERBIBLE]: 'Blue Letter Bible',
+  [BibleApps.OLIVETREE]: 'Olive Tree App',
+};
+
+export const bibleAppOptions = Object.entries(bibleAppNames).map(([value, text]) => ({ text, value }));
+
+export const localeVersionGroups: Record<LocaleCode, readonly string[]> = {
+  en: ['AMP', 'KJV', 'NKJV', 'NIV', 'ESV', 'NASB1995', 'NASB2020', 'NABRE', 'NLT', 'TPT', 'MSG'],
+  de: ['LUT'],
+  es: ['RVR1960', 'RVR2020'],
+  fr: ['BDS', 'LSG'],
+  ko: ['KLB', 'KRV'],
+  pt: ['ARC'],
+  uk: ['UKR'],
+};


### PR DESCRIPTION
When selecting a preferred Bible translation, the translations for the currently active locale will now appear at the top of the list.

This PR also consolidates Bible app and translation display names into the shared project.
