### PR TITLE
Track daily reminder engagement with a send counter instead of a time…

### DIFF
--- a/api/mongo/documents.ts
+++ b/api/mongo/documents.ts
@@ -84,7 +84,7 @@ export interface DailyReminderDocument {
   timezoneOffset: number;
   active: boolean;
   publicToken: string;
-  lastEmailEngagementAt: Date | null;
+  emailsSentSinceLastEngagement: number;
   nextOccurrence: number;
   createdAt: Date;
   updatedAt: Date;

--- a/api/repositories/daily-reminder.repository.ts
+++ b/api/repositories/daily-reminder.repository.ts
@@ -39,7 +39,7 @@ const toDailyReminderRecord = (reminder: DailyReminderDocument): DailyReminderRe
     timezoneOffset: reminder.timezoneOffset,
     active: reminder.active,
     publicToken: reminder.publicToken,
-    lastEmailEngagementAt: reminder.lastEmailEngagementAt ?? null,
+    emailsSentSinceLastEngagement: reminder.emailsSentSinceLastEngagement,
     nextOccurrence: reminder.nextOccurrence,
   };
 };
@@ -58,7 +58,7 @@ export const createDailyReminderRepository = ({ dailyReminders }: Collections) =
           timezoneOffset: reminder.timezoneOffset,
           active: reminder.active,
           publicToken: reminder.publicToken,
-          lastEmailEngagementAt: reminder.lastEmailEngagementAt,
+          emailsSentSinceLastEngagement: reminder.emailsSentSinceLastEngagement,
           nextOccurrence: reminder.nextOccurrence,
           updatedAt: reminder.updatedAt,
         },
@@ -87,7 +87,7 @@ export const createDailyReminderRepository = ({ dailyReminders }: Collections) =
       timezoneOffset: 0,
       active: false,
       publicToken: crypto.randomBytes(16).toString('base64url'),
-      lastEmailEngagementAt: null,
+      emailsSentSinceLastEngagement: 0,
       nextOccurrence: now.getTime(),
       createdAt: now,
       updatedAt: now,
@@ -112,10 +112,10 @@ export const createDailyReminderRepository = ({ dailyReminders }: Collections) =
       if (typeof patch.active !== 'undefined') { reminder.active = patch.active; }
 
       // If the daily reminder was just activated, rotate the public token
-      // (email links, tracking, unsubscribe) and seed engagement tracking.
+      // (email links, tracking, unsubscribe) and reset engagement tracking.
       if (!wasActive && reminder.active) {
         reminder.publicToken = crypto.randomBytes(16).toString('base64url');
-        reminder.lastEmailEngagementAt = new Date();
+        reminder.emailsSentSinceLastEngagement = 0;
       }
 
       assertValidSchedule(reminder);
@@ -124,11 +124,11 @@ export const createDailyReminderRepository = ({ dailyReminders }: Collections) =
       return toDailyReminderRecord(reminder);
     },
 
-    /** Updates lastEmailEngagementAt for the reminder with the given public token, if any. */
+    /** Resets emailsSentSinceLastEngagement for the reminder with the given public token, if any. */
     async recordEngagement(publicToken: string): Promise<void> {
       const reminder = await dailyReminders.findOne({ publicToken });
       if (reminder) {
-        reminder.lastEmailEngagementAt = new Date();
+        reminder.emailsSentSinceLastEngagement = 0;
         recomputeNextOccurrence(reminder);
         await persist(reminder);
       }
@@ -169,18 +169,15 @@ export const createDailyReminderRepository = ({ dailyReminders }: Collections) =
     },
 
     /**
-     * Advances a reminder's schedule by recomputing nextOccurrence and saving.
-     * Reminders created before engagement tracking have no lastEmailEngagementAt;
-     * this seeds it so they are not deactivated on the next cycle.
+     * Advances a reminder's schedule ahead of sending an email: increments
+     * emailsSentSinceLastEngagement and recomputes nextOccurrence, then saves.
      */
     async advanceSchedule(id: string): Promise<void> {
       const reminder = await dailyReminders.findOne({ _id: new ObjectId(id) });
       if (!reminder) {
         return;
       }
-      if (!reminder.lastEmailEngagementAt) {
-        reminder.lastEmailEngagementAt = new Date();
-      }
+      reminder.emailsSentSinceLastEngagement += 1;
       recomputeNextOccurrence(reminder);
       await persist(reminder);
     },

--- a/api/repositories/helpers/types.ts
+++ b/api/repositories/helpers/types.ts
@@ -166,7 +166,7 @@ export interface DailyReminderRecord {
   timezoneOffset: number;
   active: boolean;
   publicToken: string;
-  lastEmailEngagementAt: Date | null;
+  emailsSentSinceLastEngagement: number;
   nextOccurrence: number;
 }
 

--- a/api/scripts/migrate.ts
+++ b/api/scripts/migrate.ts
@@ -120,6 +120,20 @@ const main = async (): Promise<void> => {
     console.log(`Feedback __v removal complete (matched ${result.matchedCount}, modified ${result.modifiedCount}).`);
   }
 
+  // DailyReminder: replace legacy lastEmailEngagementAt timestamp with emailsSentSinceLastEngagement counter
+  const remindersWithLegacyEngagementField = await dailyReminders.countDocuments({ lastEmailEngagementAt: { $exists: true } });
+  if (remindersWithLegacyEngagementField === 0) {
+    console.log('DailyReminder lastEmailEngagementAt -> emailsSentSinceLastEngagement: already migrated (no legacy field).');
+  }
+  else {
+    console.log(`DailyReminder: migrating lastEmailEngagementAt to emailsSentSinceLastEngagement on ${remindersWithLegacyEngagementField} document(s)...`);
+    const result = await dailyReminders.updateMany(
+      {},
+      { $set: { emailsSentSinceLastEngagement: 0 }, $unset: { lastEmailEngagementAt: '' } },
+    );
+    console.log(`DailyReminder engagement migration complete (matched ${result.matchedCount}, modified ${result.modifiedCount}).`);
+  }
+
   // close connection
   await closeConnection();
 };

--- a/api/services/reminder.service.ts
+++ b/api/services/reminder.service.ts
@@ -5,8 +5,7 @@ import { DailyReminderRecord, LogEntryRecord, UserRecord } from '../repositories
 import renderDailyReminderEmail from './email/email-templates/daily-reminder';
 import { EmailService } from './email/email-service';
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-const TIME_BEFORE_DISABLING_DAILY_REMINDER_EMAIL_MS = 3 * DAY_MS;
+const MAX_EMAILS_SINCE_LAST_ENGAGEMENT = 3;
 
 const init = async ({ emailService }: { emailService: EmailService }) => {
   const { siteUrl, emailUnsubscribeAddress, emailSendingDomain } = getConfig();
@@ -132,11 +131,9 @@ const init = async ({ emailService }: { emailService: EmailService }) => {
   };
 
   const sendReminder = async (reminder: DailyReminderRecord) => {
-    const engagementCutoffMs = Date.now() - TIME_BEFORE_DISABLING_DAILY_REMINDER_EMAIL_MS;
-
-    // Reminders created before engagement tracking have no lastEmailEngagementAt;
-    // treat them as engaged (advanceSchedule seeds the field when it saves).
-    if (reminder.lastEmailEngagementAt && reminder.lastEmailEngagementAt.getTime() < engagementCutoffMs) {
+    // If the user hasn't engaged with the last MAX_EMAILS_SINCE_LAST_ENGAGEMENT
+    // reminder emails, disable the reminder instead of sending another one.
+    if (reminder.emailsSentSinceLastEngagement >= MAX_EMAILS_SINCE_LAST_ENGAGEMENT) {
       await dailyReminders.deactivate(reminder.id);
       return;
     }
@@ -148,8 +145,8 @@ const init = async ({ emailService }: { emailService: EmailService }) => {
     const recentLogEntries = await getRecentLogEntries(user);
     const email = buildEmail(user, reminder, recentLogEntries);
 
-    // Update nextOccurrence before sending email to avoid duplicate emails
-    // (the repository saves the document, triggering the pre-save hook).
+    // Update nextOccurrence and increment emailsSentSinceLastEngagement before
+    // sending email to avoid duplicate emails (the repository saves the document).
     await dailyReminders.advanceSchedule(reminder.id);
 
     // Send email after database is updated

--- a/api/test/repositories/daily-reminder.repository.test.ts
+++ b/api/test/repositories/daily-reminder.repository.test.ts
@@ -24,7 +24,7 @@ describe('daily-reminder.repository', () => {
       expect(reminder.active).toBe(false);
       expect(reminder.publicToken).toMatch(/^[A-Za-z0-9_-]+$/); // base64url
       expect(typeof reminder.nextOccurrence).toBe('number');
-      expect(reminder.lastEmailEngagementAt).toBeNull();
+      expect(reminder.emailsSentSinceLastEngagement).toBe(0);
     });
 
     it('is idempotent (returns the same reminder, never a second document)', async () => {
@@ -61,15 +61,16 @@ describe('daily-reminder.repository', () => {
       expect(updated.nextOccurrence).toBeGreaterThan(Date.now());
     });
 
-    it('rotates the public token and seeds lastEmailEngagementAt on activation', async () => {
+    it('rotates the public token and resets emailsSentSinceLastEngagement on activation', async () => {
       const { dailyReminders } = await getRepos();
       const created = await dailyReminders.getOrCreateForOwner(ownerId);
+      await dailyReminders.advanceSchedule(created.id);
 
       const activated = await dailyReminders.updateForOwner(ownerId, { active: true });
 
       expect(activated.active).toBe(true);
       expect(activated.publicToken).not.toBe(created.publicToken);
-      expect(activated.lastEmailEngagementAt).toBeInstanceOf(Date);
+      expect(activated.emailsSentSinceLastEngagement).toBe(0);
     });
 
     it('rejects out-of-range hour, minute, and timezone offset', async () => {
@@ -83,14 +84,15 @@ describe('daily-reminder.repository', () => {
   });
 
   describe('engagement and deactivation', () => {
-    it('recordEngagement stamps lastEmailEngagementAt by public token', async () => {
+    it('recordEngagement resets emailsSentSinceLastEngagement by public token', async () => {
       const { dailyReminders } = await getRepos();
       const created = await dailyReminders.getOrCreateForOwner(ownerId);
+      await dailyReminders.advanceSchedule(created.id);
 
       await dailyReminders.recordEngagement(created.publicToken);
 
       const after = await dailyReminders.getOrCreateForOwner(ownerId);
-      expect(after.lastEmailEngagementAt).toBeInstanceOf(Date);
+      expect(after.emailsSentSinceLastEngagement).toBe(0);
     });
 
     it('deactivateByPublicToken deactivates a reminder or returns null for an unknown token', async () => {
@@ -112,15 +114,15 @@ describe('daily-reminder.repository', () => {
       expect(after.active).toBe(false);
     });
 
-    it('advanceSchedule seeds lastEmailEngagementAt and recomputes nextOccurrence', async () => {
+    it('advanceSchedule increments emailsSentSinceLastEngagement and recomputes nextOccurrence', async () => {
       const { dailyReminders } = await getRepos();
       const created = await dailyReminders.getOrCreateForOwner(ownerId);
-      expect(created.lastEmailEngagementAt).toBeNull();
+      expect(created.emailsSentSinceLastEngagement).toBe(0);
 
       await dailyReminders.advanceSchedule(created.id);
 
       const after = await dailyReminders.getOrCreateForOwner(ownerId);
-      expect(after.lastEmailEngagementAt).toBeInstanceOf(Date);
+      expect(after.emailsSentSinceLastEngagement).toBe(1);
       expect(after.nextOccurrence).toBeGreaterThan(Date.now());
     });
   });


### PR DESCRIPTION
Track daily reminder engagement with a send counter instead of a timestamp.
