### PR TITLE
Fix locale switcher not updating content on nuxt4 content pages

### DIFF
--- a/nuxt4/app/pages/[slug].vue
+++ b/nuxt4/app/pages/[slug].vue
@@ -15,8 +15,10 @@ const { locale } = useI18n();
 
 const slug = route.params.slug as string;
 
-const { data: page } = await useAsyncData(`content-${slug}`, () =>
-  queryCollection('content').path(`/${locale.value}/${slug}`).first(),
+const { data: page } = await useAsyncData(
+  () => `content-${slug}-${locale.value}`,
+  () => queryCollection('content').path(`/${locale.value}/${slug}`).first(),
+  { watch: [locale] },
 );
 
 if (!page.value) {

--- a/nuxt4/app/pages/about/[slug].vue
+++ b/nuxt4/app/pages/about/[slug].vue
@@ -30,8 +30,10 @@ const slug = route.params.slug as string;
 // matches the URL the visitor (and crawler) actually requested.
 const contentSlug = slug.replace(/-{2,}/g, '-');
 
-const { data: page, error } = await useAsyncData(`about-${slug}`, () =>
-  queryCollection('content').path(`/${locale.value}/about/${contentSlug}`).first(),
+const { data: page, error } = await useAsyncData(
+  () => `about-${slug}-${locale.value}`,
+  () => queryCollection('content').path(`/${locale.value}/about/${contentSlug}`).first(),
+  { watch: [locale] },
 );
 
 // Redirect to overview if page not found

--- a/nuxt4/app/pages/index.vue
+++ b/nuxt4/app/pages/index.vue
@@ -18,8 +18,10 @@ if (authStore.loggedIn) {
   await navigateTo(localePath('/start'));
 }
 
-const { data: page } = await useAsyncData('home', () =>
-  queryCollection('content').path(`/${locale.value}`).first(),
+const { data: page } = await useAsyncData(
+  () => `home-${locale.value}`,
+  () => queryCollection('content').path(`/${locale.value}`).first(),
+  { watch: [locale] },
 );
 
 if (!page.value) {

--- a/nuxt4/app/pages/policy/[slug].vue
+++ b/nuxt4/app/pages/policy/[slug].vue
@@ -15,8 +15,10 @@ const { locale } = useI18n();
 
 const slug = route.params.slug as string;
 
-const { data: page } = await useAsyncData(`policy-${slug}`, () =>
-  queryCollection('content').path(`/${locale.value}/policy/${slug}`).first(),
+const { data: page } = await useAsyncData(
+  () => `policy-${slug}-${locale.value}`,
+  () => queryCollection('content').path(`/${locale.value}/policy/${slug}`).first(),
+  { watch: [locale] },
 );
 
 if (!page.value) {


### PR DESCRIPTION
In Nuxt 4, changing locales on a content page did not update the page, even though the URL was updated.

This fixes that bug.